### PR TITLE
Обновление webpack.prod.js minimizer plugins

### DIFF
--- a/env/webpack.prod.js
+++ b/env/webpack.prod.js
@@ -6,6 +6,7 @@ module.exports = merge(common, {
   mode: 'production',
   optimization: {
     minimizer: [
+      `...`,
       new CssMinimizerPlugin(),
     ],
   },


### PR DESCRIPTION
Спиоск минимайзеров в webpack.prod.js был обновлен, чтобы оптимизировать сборку на продакшн. До изменений JS в итоговом бандле собирался без минимизации из-за неправильно имплементации CssMinimizerPlugin, которая исключала из процесса сборки TerserPlugin, нужный для минимизации js-кода. Из-за чего он получался больших размеров. 

Closes #4 